### PR TITLE
Feature implementation from commits 4055827..fe5bcc1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ test:
 	  echo "go test in $${dir}"; \
 	  (cd "$${dir}" && \
 	    go test && \
+	    env RACETEST=1 go test -race && \
 	    env GOOS=linux GOARCH=386 TZ= go test && \
 	    go vet); \
 	done

--- a/dialect/pgdialect/alter_table.go
+++ b/dialect/pgdialect/alter_table.go
@@ -1,6 +1,7 @@
 package pgdialect
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -57,6 +58,11 @@ func (m *migrator) AppendSQL(b []byte, operation interface{}) (_ []byte, err err
 	case *migrate.DropUniqueConstraintOp:
 		b, err = m.dropConstraint(fmter, appendAlterTable(b, change.TableName), change.Unique.Name)
 	case *migrate.ChangeColumnTypeOp:
+		// If column changes to SERIAL, create sequence first.
+		// https://gist.github.com/oleglomako/185df689706c5499612a0d54d3ffe856
+		if !change.From.GetIsAutoIncrement() && change.To.GetIsAutoIncrement() {
+			change.To, b, err = m.createDefaultSequence(fmter, b, change)
+		}
 		b, err = m.changeColumnType(fmter, appendAlterTable(b, change.TableName), change)
 	case *migrate.AddForeignKeyOp:
 		b, err = m.addForeignKey(fmter, appendAlterTable(b, change.TableName()), change)
@@ -185,6 +191,41 @@ func (m *migrator) addForeignKey(fmter schema.Formatter, b []byte, add *migrate.
 	b = append(b, ")"...)
 
 	return b, nil
+}
+
+// createDefaultSequence creates a SEQUENCE to back a serial column.
+// Having a backing sequence is necessary to change column type to SERIAL.
+// The updated Column's default is  set to "nextval" of the new sequence.
+func (m *migrator) createDefaultSequence(_ schema.Formatter, b []byte, op *migrate.ChangeColumnTypeOp) (_ sqlschema.Column, _ []byte, err error) {
+	var start int
+	if err = m.db.NewSelect().Table(op.TableName).
+		ColumnExpr("MAX(?)", op.Column).Scan(context.TODO(), &start); err != nil {
+		return nil, b, err
+	}
+	start = max(start, 1) // cannot be less than 1
+
+	seq := op.TableName + "_" + op.Column + "_seq"
+	fqn := op.TableName + "." + op.Column
+
+	// A sequence that is OWNED BY a table will be dropped
+	// if the table is dropped with CASCADE action.
+	b = append(b, "CREATE SEQUENCE "...)
+	b = append(b, seq...)
+	b = append(b, " START WITH "...)
+	b = append(b, fmt.Sprint(start)...)
+	b = append(b, " OWNED BY "...)
+	b = append(b, fqn...)
+	b = append(b, ";\n"...)
+
+	return &Column{
+		Name:            op.To.GetName(),
+		SQLType:         op.To.GetSQLType(),
+		VarcharLen:      op.To.GetVarcharLen(),
+		DefaultValue:    fmt.Sprintf("nextval('%s'::regclass)", seq),
+		IsNullable:      op.To.GetIsNullable(),
+		IsAutoIncrement: op.To.GetIsAutoIncrement(),
+		IsIdentity:      op.To.GetIsIdentity(),
+	}, b, nil
 }
 
 func (m *migrator) changeColumnType(fmter schema.Formatter, b []byte, colDef *migrate.ChangeColumnTypeOp) (_ []byte, err error) {

--- a/dialect/pgdialect/inspector.go
+++ b/dialect/pgdialect/inspector.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/uptrace/bun"
-	"github.com/uptrace/bun/internal/ordered"
 	"github.com/uptrace/bun/migrate/sqlschema"
 )
 
@@ -60,7 +59,7 @@ func (in *Inspector) Inspect(ctx context.Context) (sqlschema.Database, error) {
 			return dbSchema, err
 		}
 
-		colDefs := ordered.NewMap[string, sqlschema.Column]()
+		var colDefs []sqlschema.Column
 		uniqueGroups := make(map[string][]string)
 
 		for _, c := range columns {
@@ -71,7 +70,7 @@ func (in *Inspector) Inspect(ctx context.Context) (sqlschema.Database, error) {
 				def = strings.ToLower(def)
 			}
 
-			colDefs.Store(c.Name, &Column{
+			colDefs = append(colDefs, &Column{
 				Name:            c.Name,
 				SQLType:         c.DataType,
 				VarcharLen:      c.VarcharLen,

--- a/dialect/pgdialect/inspector.go
+++ b/dialect/pgdialect/inspector.go
@@ -34,7 +34,6 @@ func newInspector(db *bun.DB, options ...sqlschema.InspectorOption) *Inspector {
 
 func (in *Inspector) Inspect(ctx context.Context) (sqlschema.Database, error) {
 	dbSchema := Schema{
-		Tables:      ordered.NewMap[string, sqlschema.Table](),
 		ForeignKeys: make(map[sqlschema.ForeignKey]string),
 	}
 
@@ -103,7 +102,7 @@ func (in *Inspector) Inspect(ctx context.Context) (sqlschema.Database, error) {
 			}
 		}
 
-		dbSchema.Tables.Store(table.Name, &Table{
+		dbSchema.Tables = append(dbSchema.Tables, &Table{
 			Schema:            table.Schema,
 			Name:              table.Name,
 			Columns:           colDefs,

--- a/dialect/pgdialect/sqltype.go
+++ b/dialect/pgdialect/sqltype.go
@@ -127,6 +127,9 @@ var (
 	char        = newAliases(pgTypeChar, pgTypeCharacter)
 	varchar     = newAliases(pgTypeVarchar, pgTypeCharacterVarying)
 	timestampTz = newAliases(sqltype.Timestamp, pgTypeTimestampTz, pgTypeTimestampWithTz)
+	bigint      = newAliases(sqltype.BigInt, pgTypeBigSerial)
+	integer     = newAliases(sqltype.Integer, pgTypeSerial)
+	smallint    = newAliases(sqltype.SmallInt, pgTypeSmallSerial)
 )
 
 func (d *Dialect) CompareType(col1, col2 sqlschema.Column) bool {
@@ -142,6 +145,10 @@ func (d *Dialect) CompareType(col1, col2 sqlschema.Column) bool {
 	case varchar.IsAlias(typ1) && varchar.IsAlias(typ2):
 		return checkVarcharLen(col1, col2, d.DefaultVarcharLen())
 	case timestampTz.IsAlias(typ1) && timestampTz.IsAlias(typ2):
+		return true
+	case bigint.IsAlias(typ1) && bigint.IsAlias(typ2),
+		integer.IsAlias(typ1) && integer.IsAlias(typ2),
+		smallint.IsAlias(typ1) && smallint.IsAlias(typ2):
 		return true
 	}
 	return false

--- a/dialect/pgdialect/sqltype_test.go
+++ b/dialect/pgdialect/sqltype_test.go
@@ -35,6 +35,11 @@ func TestInspectorDialect_CompareType(t *testing.T) {
 			{sqltype.Timestamp, pgTypeTimestamp, true}, // Still, TIMESTAMP == TIMESTAMP
 			{sqltype.Timestamp, pgTypeTimeTz, false},
 			{pgTypeTimestampTz, pgTypeTimestampWithTz, true},
+
+			// SERIAL is an alias to INT + auto-generated sequence
+			{sqltype.BigInt, pgTypeBigSerial, true},
+			{sqltype.Integer, pgTypeSerial, true},
+			{sqltype.SmallInt, pgTypeSmallSerial, true},
 		} {
 			eq := " ~ "
 			if !tt.want {
@@ -48,7 +53,6 @@ func TestInspectorDialect_CompareType(t *testing.T) {
 				require.Equal(t, tt.want, got)
 			})
 		}
-
 	})
 
 	t.Run("custom varchar length", func(t *testing.T) {

--- a/driver/pgdriver/listener_test.go
+++ b/driver/pgdriver/listener_test.go
@@ -1,0 +1,28 @@
+package pgdriver
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithChannelOverflowHandler(t *testing.T) {
+	// Create a test handler
+	testHandler := func(n Notification) {}
+
+	// Create a channel instance
+	c := &channel{}
+
+	// Apply the option
+	opt := WithChannelOverflowHandler(testHandler)
+	opt(c)
+
+	// Verify the handler was set correctly
+	assert.NotNil(t, c.overflowHandler, "overflow handler should be set")
+	assert.Equal(t,
+		reflect.ValueOf(testHandler).Pointer(),
+		reflect.ValueOf(c.overflowHandler).Pointer(),
+		"overflow handler should match the provided handler",
+	)
+}

--- a/internal/dbtest/db_test.go
+++ b/internal/dbtest/db_test.go
@@ -2006,6 +2006,8 @@ func testWithPointerPrimaryKeyHasManyWithDriverValuer(t *testing.T, db *bun.DB) 
 	require.Len(t, program.Items, 2)
 }
 
+// TODO: Investigate and fix race conditions in other dialects for this test.
+// See https://github.com/uptrace/bun/pull/1146
 func testRelationJoinDataRace(t *testing.T, db *bun.DB) {
 	if db.Dialect().Name().String() != pgName {
 		return

--- a/internal/dbtest/db_test.go
+++ b/internal/dbtest/db_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -35,7 +36,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var ctx = context.TODO()
+var (
+	ctx        = context.TODO()
+	isRaceTest = os.Getenv("RACETEST") != ""
+)
 
 const (
 	pgName        = "pg"
@@ -304,6 +308,7 @@ func TestDB(t *testing.T) {
 		{testNoPanicWhenReturningNullColumns},
 		{testNoForeignKeyForPrimaryKey},
 		{testWithPointerPrimaryKeyHasManyWithDriverValuer},
+		{testRelationJoinDataRace},
 	}
 
 	testEachDB(t, func(t *testing.T, dbName string, db *bun.DB) {
@@ -1999,4 +2004,41 @@ func testWithPointerPrimaryKeyHasManyWithDriverValuer(t *testing.T, db *bun.DB) 
 	err = db.NewSelect().Model(&program).Relation("Items").Scan(ctx)
 	require.NoError(t, err)
 	require.Len(t, program.Items, 2)
+}
+
+func testRelationJoinDataRace(t *testing.T, db *bun.DB) {
+	if db.Dialect().Name().String() != pgName {
+		return
+	}
+
+	type RacePost struct {
+		PostID  int64 `bun:",pk,autoincrement"`
+		UserID  int64
+		Message string
+	}
+	type RaceUser struct {
+		UserID int64 `bun:",pk,autoincrement"`
+		Name   string
+		Posts  *RacePost `bun:"rel:has-one,join:user_id=user_id"`
+	}
+
+	mustResetModel(t, ctx, db, (*RaceUser)(nil), (*RacePost)(nil))
+
+	for j := 0; j < 10; j++ {
+		user := &RaceUser{Name: fmt.Sprintf("user %d", j)}
+		_, err := db.NewInsert().Model(user).Returning("user_id").Exec(ctx, user)
+		require.NoError(t, err)
+
+		i := 0
+		post := &RacePost{
+			Message: fmt.Sprintf("message %d", i),
+			UserID:  user.UserID,
+		}
+		_, err = db.NewInsert().Model(post).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	var users []RaceUser
+	_, err := db.NewSelect().Model(&users).Relation("Posts").Offset(1).ScanAndCount(ctx)
+	require.NoError(t, err)
 }

--- a/internal/dbtest/inspect_test.go
+++ b/internal/dbtest/inspect_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect/sqltype"
-	"github.com/uptrace/bun/internal/ordered"
 	"github.com/uptrace/bun/migrate/sqlschema"
 	"github.com/uptrace/bun/schema"
 )
@@ -91,81 +90,65 @@ func TestDatabaseInspector_Inspect(t *testing.T) {
 					&sqlschema.BaseTable{
 						Schema: defaultSchema,
 						Name:   "articles",
-						Columns: ordered.NewMap[string, sqlschema.Column](
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "isbn",
-								Value: &sqlschema.BaseColumn{
-									SQLType:         "bigint",
-									IsNullable:      false,
-									IsAutoIncrement: false,
-									IsIdentity:      true,
-									DefaultValue:    "",
-								},
+						Columns: []sqlschema.Column{
+							&sqlschema.BaseColumn{
+								Name:            "isbn",
+								SQLType:         "bigint",
+								IsNullable:      false,
+								IsAutoIncrement: false,
+								IsIdentity:      true,
+								DefaultValue:    "",
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "editor",
-								Value: &sqlschema.BaseColumn{
-									SQLType:         sqltype.VarChar,
-									IsNullable:      false,
-									IsAutoIncrement: false,
-									IsIdentity:      false,
-									DefaultValue:    "john doe",
-								},
+							&sqlschema.BaseColumn{
+								Name:            "editor",
+								SQLType:         sqltype.VarChar,
+								IsNullable:      false,
+								IsAutoIncrement: false,
+								IsIdentity:      false,
+								DefaultValue:    "john doe",
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "title",
-								Value: &sqlschema.BaseColumn{
-									SQLType:         sqltype.VarChar,
-									IsNullable:      false,
-									IsAutoIncrement: false,
-									IsIdentity:      false,
-									DefaultValue:    "",
-								},
+							&sqlschema.BaseColumn{
+								Name:            "title",
+								SQLType:         sqltype.VarChar,
+								IsNullable:      false,
+								IsAutoIncrement: false,
+								IsIdentity:      false,
+								DefaultValue:    "",
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "locale",
-								Value: &sqlschema.BaseColumn{
-									SQLType:         sqltype.VarChar,
-									VarcharLen:      5,
-									IsNullable:      true,
-									IsAutoIncrement: false,
-									IsIdentity:      false,
-									DefaultValue:    "en-GB",
-								},
+							&sqlschema.BaseColumn{
+								Name:            "locale",
+								SQLType:         sqltype.VarChar,
+								VarcharLen:      5,
+								IsNullable:      true,
+								IsAutoIncrement: false,
+								IsIdentity:      false,
+								DefaultValue:    "en-GB",
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "page_count",
-								Value: &sqlschema.BaseColumn{
-									SQLType:         "smallint",
-									IsNullable:      false,
-									IsAutoIncrement: false,
-									IsIdentity:      false,
-									DefaultValue:    "1",
-								},
+							&sqlschema.BaseColumn{
+								Name:            "page_count",
+								SQLType:         "smallint",
+								IsNullable:      false,
+								IsAutoIncrement: false,
+								IsIdentity:      false,
+								DefaultValue:    "1",
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "book_count",
-								Value: &sqlschema.BaseColumn{
-									SQLType:         "integer",
-									IsNullable:      false,
-									IsAutoIncrement: true,
-									IsIdentity:      false,
-									DefaultValue:    "",
-								},
+							&sqlschema.BaseColumn{
+								Name:            "book_count",
+								SQLType:         "integer",
+								IsNullable:      false,
+								IsAutoIncrement: true,
+								IsIdentity:      false,
+								DefaultValue:    "",
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "publisher_id",
-								Value: &sqlschema.BaseColumn{
-									SQLType: sqltype.VarChar,
-								},
+							&sqlschema.BaseColumn{
+								Name:    "publisher_id",
+								SQLType: sqltype.VarChar,
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "author_id",
-								Value: &sqlschema.BaseColumn{
-									SQLType: "bigint",
-								},
+							&sqlschema.BaseColumn{
+								Name:    "author_id",
+								SQLType: "bigint",
 							},
-						),
+						},
 						PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("isbn")},
 						UniqueConstraints: []sqlschema.Unique{
 							{Columns: sqlschema.NewColumns("editor", "title")},
@@ -174,33 +157,25 @@ func TestDatabaseInspector_Inspect(t *testing.T) {
 					&sqlschema.BaseTable{
 						Schema: defaultSchema,
 						Name:   "authors",
-						Columns: ordered.NewMap[string, sqlschema.Column](
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "author_id",
-								Value: &sqlschema.BaseColumn{
-									SQLType:    "bigint",
-									IsIdentity: true,
-								},
+						Columns: []sqlschema.Column{
+							&sqlschema.BaseColumn{
+								Name:       "author_id",
+								SQLType:    "bigint",
+								IsIdentity: true,
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "first_name",
-								Value: &sqlschema.BaseColumn{
-									SQLType: sqltype.VarChar,
-								},
+							&sqlschema.BaseColumn{
+								Name:    "first_name",
+								SQLType: sqltype.VarChar,
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "last_name",
-								Value: &sqlschema.BaseColumn{
-									SQLType: sqltype.VarChar,
-								},
+							&sqlschema.BaseColumn{
+								Name:    "last_name",
+								SQLType: sqltype.VarChar,
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "email",
-								Value: &sqlschema.BaseColumn{
-									SQLType: sqltype.VarChar,
-								},
+							&sqlschema.BaseColumn{
+								Name:    "email",
+								SQLType: sqltype.VarChar,
 							},
-						),
+						},
 						PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("author_id")},
 						UniqueConstraints: []sqlschema.Unique{
 							{Columns: sqlschema.NewColumns("first_name", "last_name")},
@@ -210,48 +185,38 @@ func TestDatabaseInspector_Inspect(t *testing.T) {
 					&sqlschema.BaseTable{
 						Schema: defaultSchema,
 						Name:   "publisher_to_journalists",
-						Columns: ordered.NewMap[string, sqlschema.Column](
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "publisher_id",
-								Value: &sqlschema.BaseColumn{
-									SQLType: sqltype.VarChar,
-								},
+						Columns: []sqlschema.Column{
+							&sqlschema.BaseColumn{
+								Name:    "publisher_id",
+								SQLType: sqltype.VarChar,
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "author_id",
-								Value: &sqlschema.BaseColumn{
-									SQLType: "bigint",
-								},
+							&sqlschema.BaseColumn{
+								Name:    "author_id",
+								SQLType: "bigint",
 							},
-						),
+						},
 						PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("publisher_id", "author_id")},
 					},
 					&sqlschema.BaseTable{
 						Schema: defaultSchema,
 						Name:   "publishers",
-						Columns: ordered.NewMap[string, sqlschema.Column](
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "publisher_id",
-								Value: &sqlschema.BaseColumn{
-									SQLType:      sqltype.VarChar,
-									DefaultValue: "gen_random_uuid()",
-								},
+						Columns: []sqlschema.Column{
+							&sqlschema.BaseColumn{
+								Name:         "publisher_id",
+								SQLType:      sqltype.VarChar,
+								DefaultValue: "gen_random_uuid()",
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "publisher_name",
-								Value: &sqlschema.BaseColumn{
-									SQLType: sqltype.VarChar,
-								},
+							&sqlschema.BaseColumn{
+								Name:    "publisher_name",
+								SQLType: sqltype.VarChar,
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "created_at",
-								Value: &sqlschema.BaseColumn{
-									SQLType:      "timestamp",
-									DefaultValue: "current_timestamp",
-									IsNullable:   true,
-								},
+							&sqlschema.BaseColumn{
+								Name:         "created_at",
+								SQLType:      "timestamp",
+								DefaultValue: "current_timestamp",
+								IsNullable:   true,
 							},
-						),
+						},
 						PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("publisher_id")},
 						UniqueConstraints: []sqlschema.Unique{
 							{Columns: sqlschema.NewColumns("publisher_id", "publisher_name")},
@@ -284,28 +249,22 @@ func TestDatabaseInspector_Inspect(t *testing.T) {
 					&sqlschema.BaseTable{
 						Schema: "admin",
 						Name:   "offices",
-						Columns: ordered.NewMap[string, sqlschema.Column](
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "office_name",
-								Value: &sqlschema.BaseColumn{
-									SQLType: sqltype.VarChar,
-								},
+						Columns: []sqlschema.Column{
+							&sqlschema.BaseColumn{
+								Name:    "office_name",
+								SQLType: sqltype.VarChar,
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "publisher_id",
-								Value: &sqlschema.BaseColumn{
-									SQLType:    sqltype.VarChar,
-									IsNullable: true,
-								},
+							&sqlschema.BaseColumn{
+								Name:       "publisher_id",
+								SQLType:    sqltype.VarChar,
+								IsNullable: true,
 							},
-							ordered.Pair[string, sqlschema.Column]{
-								Key: "publisher_name",
-								Value: &sqlschema.BaseColumn{
-									SQLType:    sqltype.VarChar,
-									IsNullable: true,
-								},
+							&sqlschema.BaseColumn{
+								Name:       "publisher_name",
+								SQLType:    sqltype.VarChar,
+								IsNullable: true,
 							},
-						),
+						},
 						PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("office_name")},
 					},
 				},
@@ -391,9 +350,9 @@ func cmpTables(
 	// They might still appear in a different order, here's a helper to find matching tables.
 	findGot := func(t testing.TB, name string) sqlschema.Table {
 		t.Helper()
-		for _, t := range got {
-			if t.GetName() == name {
-				return t
+		for _, table := range got {
+			if table.GetName() == name {
+				return table
 			}
 		}
 		// This should never happen, as we've verified that table names match.
@@ -413,21 +372,35 @@ func cmpColumns(
 	tb testing.TB,
 	d sqlschema.InspectorDialect,
 	tableName string,
-	want, got *ordered.Map[string, sqlschema.Column],
+	want, got []sqlschema.Column,
 ) {
 	tb.Helper()
 	var errs []string
 
 	var missing []string
-	for _, cPair := range want.Pairs() {
-		colName := cPair.Key
+	findGot := func(name string) sqlschema.Column {
+		for _, col := range got {
+			if col.GetName() == name {
+				return col
+			}
+		}
+		// This should never happen, as we've verified that table names match.
+		missing = append(missing, name)
+		return nil
+	}
+
+	wantColumnNames := make(map[string]struct{}, len(want))
+	for _, wantColumn := range want {
+		colName := wantColumn.GetName()
+		wantColumnNames[colName] = struct{}{}
+
 		errorf := func(format string, args ...interface{}) {
 			errs = append(errs, fmt.Sprintf("[%s.%s] "+format, append([]interface{}{tableName, colName}, args...)...))
 		}
-		wantCol := cPair.Value.(*sqlschema.BaseColumn)
-		gotCol, ok := got.Value(colName).(*sqlschema.BaseColumn)
-		if !ok {
-			missing = append(missing, colName)
+
+		wantCol := wantColumn.(*sqlschema.BaseColumn)
+		gotCol := findGot(colName).(*sqlschema.BaseColumn)
+		if gotCol == nil {
 			continue
 		}
 
@@ -457,9 +430,9 @@ func cmpColumns(
 	}
 
 	var extra []string
-	for _, colName := range got.Keys() {
-		if _, ok := want.Load(colName); !ok {
-			extra = append(extra, colName)
+	for _, c := range got {
+		if _, ok := wantColumnNames[c.GetName()]; !ok {
+			extra = append(extra, c.GetName())
 		}
 	}
 
@@ -523,22 +496,18 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 			tables.Register((*Model)(nil))
 			inspector := sqlschema.NewBunModelInspector(tables, sqlschema.WithSchemaName(dialect.DefaultSchema()))
 
-			want := ordered.NewMap[string, sqlschema.Column](
-				ordered.Pair[string, sqlschema.Column]{
-					Key: "id",
-					Value: &sqlschema.BaseColumn{
-						SQLType:      sqltype.VarChar,
-						DefaultValue: "random()",
-					},
+			want := []sqlschema.Column{
+				&sqlschema.BaseColumn{
+					Name:         "id",
+					SQLType:      sqltype.VarChar,
+					DefaultValue: "random()",
 				},
-				ordered.Pair[string, sqlschema.Column]{
-					Key: "name",
-					Value: &sqlschema.BaseColumn{
-						SQLType:      sqltype.VarChar,
-						DefaultValue: "John Doe",
-					},
+				&sqlschema.BaseColumn{
+					Name:         "name",
+					SQLType:      sqltype.VarChar,
+					DefaultValue: "John Doe",
 				},
-			)
+			}
 
 			got, err := inspector.Inspect(context.Background())
 			require.NoError(t, err)
@@ -562,28 +531,22 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 			tables.Register((*Model)(nil))
 			inspector := sqlschema.NewBunModelInspector(tables, sqlschema.WithSchemaName(dialect.DefaultSchema()))
 
-			want := ordered.NewMap[string, sqlschema.Column](
-				ordered.Pair[string, sqlschema.Column]{
-					Key: "id",
-					Value: &sqlschema.BaseColumn{
-						SQLType: "text",
-					},
+			want := []sqlschema.Column{
+				&sqlschema.BaseColumn{
+					Name:    "id",
+					SQLType: "text",
 				},
-				ordered.Pair[string, sqlschema.Column]{
-					Key: "first_name",
-					Value: &sqlschema.BaseColumn{
-						SQLType:    "character varying",
-						VarcharLen: 60,
-					},
+				&sqlschema.BaseColumn{
+					Name:       "first_name",
+					SQLType:    "character varying",
+					VarcharLen: 60,
 				},
-				ordered.Pair[string, sqlschema.Column]{
-					Key: "last_name",
-					Value: &sqlschema.BaseColumn{
-						SQLType:    "varchar",
-						VarcharLen: 100,
-					},
+				&sqlschema.BaseColumn{
+					Name:       "last_name",
+					SQLType:    "varchar",
+					VarcharLen: 100,
 				},
-			)
+			}
 
 			got, err := inspector.Inspect(context.Background())
 			require.NoError(t, err)

--- a/internal/dbtest/inspect_test.go
+++ b/internal/dbtest/inspect_test.go
@@ -79,197 +79,185 @@ func TestDatabaseInspector_Inspect(t *testing.T) {
 		for _, tt := range []struct {
 			name       string
 			schemaName string
-			wantTables *ordered.Map[string, sqlschema.Table]
+			wantTables []sqlschema.Table
 			wantFKs    []sqlschema.ForeignKey
 		}{
 			{
 				name:       "inspect default schema",
 				schemaName: defaultSchema,
 				// Tables come sorted alphabetically by schema and table.
-				wantTables: ordered.NewMap[string, sqlschema.Table](
+				wantTables: []sqlschema.Table{
 					// admin.offices should not be fetched, because it doesn't belong to the default schema.
-					ordered.Pair[string, sqlschema.Table]{
-						Key: "articles",
-						Value: &sqlschema.BaseTable{
-							Schema: defaultSchema,
-							Name:   "articles",
-							Columns: ordered.NewMap[string, sqlschema.Column](
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "isbn",
-									Value: &sqlschema.BaseColumn{
-										SQLType:         "bigint",
-										IsNullable:      false,
-										IsAutoIncrement: false,
-										IsIdentity:      true,
-										DefaultValue:    "",
-									},
+					&sqlschema.BaseTable{
+						Schema: defaultSchema,
+						Name:   "articles",
+						Columns: ordered.NewMap[string, sqlschema.Column](
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "isbn",
+								Value: &sqlschema.BaseColumn{
+									SQLType:         "bigint",
+									IsNullable:      false,
+									IsAutoIncrement: false,
+									IsIdentity:      true,
+									DefaultValue:    "",
 								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "editor",
-									Value: &sqlschema.BaseColumn{
-										SQLType:         sqltype.VarChar,
-										IsNullable:      false,
-										IsAutoIncrement: false,
-										IsIdentity:      false,
-										DefaultValue:    "john doe",
-									},
-								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "title",
-									Value: &sqlschema.BaseColumn{
-										SQLType:         sqltype.VarChar,
-										IsNullable:      false,
-										IsAutoIncrement: false,
-										IsIdentity:      false,
-										DefaultValue:    "",
-									},
-								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "locale",
-									Value: &sqlschema.BaseColumn{
-										SQLType:         sqltype.VarChar,
-										VarcharLen:      5,
-										IsNullable:      true,
-										IsAutoIncrement: false,
-										IsIdentity:      false,
-										DefaultValue:    "en-GB",
-									},
-								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "page_count",
-									Value: &sqlschema.BaseColumn{
-										SQLType:         "smallint",
-										IsNullable:      false,
-										IsAutoIncrement: false,
-										IsIdentity:      false,
-										DefaultValue:    "1",
-									},
-								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "book_count",
-									Value: &sqlschema.BaseColumn{
-										SQLType:         "integer",
-										IsNullable:      false,
-										IsAutoIncrement: true,
-										IsIdentity:      false,
-										DefaultValue:    "",
-									},
-								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "publisher_id",
-									Value: &sqlschema.BaseColumn{
-										SQLType: sqltype.VarChar,
-									},
-								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "author_id",
-									Value: &sqlschema.BaseColumn{
-										SQLType: "bigint",
-									},
-								},
-							),
-							PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("isbn")},
-							UniqueConstraints: []sqlschema.Unique{
-								{Columns: sqlschema.NewColumns("editor", "title")},
 							},
-						},
-					},
-					ordered.Pair[string, sqlschema.Table]{
-						Key: "authors",
-						Value: &sqlschema.BaseTable{
-							Schema: defaultSchema,
-							Name:   "authors",
-							Columns: ordered.NewMap[string, sqlschema.Column](
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "author_id",
-									Value: &sqlschema.BaseColumn{
-										SQLType:    "bigint",
-										IsIdentity: true,
-									},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "editor",
+								Value: &sqlschema.BaseColumn{
+									SQLType:         sqltype.VarChar,
+									IsNullable:      false,
+									IsAutoIncrement: false,
+									IsIdentity:      false,
+									DefaultValue:    "john doe",
 								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "first_name",
-									Value: &sqlschema.BaseColumn{
-										SQLType: sqltype.VarChar,
-									},
-								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "last_name",
-									Value: &sqlschema.BaseColumn{
-										SQLType: sqltype.VarChar,
-									},
-								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "email",
-									Value: &sqlschema.BaseColumn{
-										SQLType: sqltype.VarChar,
-									},
-								},
-							),
-							PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("author_id")},
-							UniqueConstraints: []sqlschema.Unique{
-								{Columns: sqlschema.NewColumns("first_name", "last_name")},
-								{Columns: sqlschema.NewColumns("email")},
 							},
-						},
-					},
-					ordered.Pair[string, sqlschema.Table]{
-						Key: "publisher_to_journalists",
-						Value: &sqlschema.BaseTable{
-							Schema: defaultSchema,
-							Name:   "publisher_to_journalists",
-							Columns: ordered.NewMap[string, sqlschema.Column](
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "publisher_id",
-									Value: &sqlschema.BaseColumn{
-										SQLType: sqltype.VarChar,
-									},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "title",
+								Value: &sqlschema.BaseColumn{
+									SQLType:         sqltype.VarChar,
+									IsNullable:      false,
+									IsAutoIncrement: false,
+									IsIdentity:      false,
+									DefaultValue:    "",
 								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "author_id",
-									Value: &sqlschema.BaseColumn{
-										SQLType: "bigint",
-									},
-								},
-							),
-							PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("publisher_id", "author_id")},
-						},
-					},
-					ordered.Pair[string, sqlschema.Table]{
-						Key: "publishers",
-						Value: &sqlschema.BaseTable{
-							Schema: defaultSchema,
-							Name:   "publishers",
-							Columns: ordered.NewMap[string, sqlschema.Column](
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "publisher_id",
-									Value: &sqlschema.BaseColumn{
-										SQLType:      sqltype.VarChar,
-										DefaultValue: "gen_random_uuid()",
-									},
-								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "publisher_name",
-									Value: &sqlschema.BaseColumn{
-										SQLType: sqltype.VarChar,
-									},
-								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "created_at",
-									Value: &sqlschema.BaseColumn{
-										SQLType:      "timestamp",
-										DefaultValue: "current_timestamp",
-										IsNullable:   true,
-									},
-								},
-							),
-							PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("publisher_id")},
-							UniqueConstraints: []sqlschema.Unique{
-								{Columns: sqlschema.NewColumns("publisher_id", "publisher_name")},
 							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "locale",
+								Value: &sqlschema.BaseColumn{
+									SQLType:         sqltype.VarChar,
+									VarcharLen:      5,
+									IsNullable:      true,
+									IsAutoIncrement: false,
+									IsIdentity:      false,
+									DefaultValue:    "en-GB",
+								},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "page_count",
+								Value: &sqlschema.BaseColumn{
+									SQLType:         "smallint",
+									IsNullable:      false,
+									IsAutoIncrement: false,
+									IsIdentity:      false,
+									DefaultValue:    "1",
+								},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "book_count",
+								Value: &sqlschema.BaseColumn{
+									SQLType:         "integer",
+									IsNullable:      false,
+									IsAutoIncrement: true,
+									IsIdentity:      false,
+									DefaultValue:    "",
+								},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "publisher_id",
+								Value: &sqlschema.BaseColumn{
+									SQLType: sqltype.VarChar,
+								},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "author_id",
+								Value: &sqlschema.BaseColumn{
+									SQLType: "bigint",
+								},
+							},
+						),
+						PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("isbn")},
+						UniqueConstraints: []sqlschema.Unique{
+							{Columns: sqlschema.NewColumns("editor", "title")},
 						},
 					},
-				),
+					&sqlschema.BaseTable{
+						Schema: defaultSchema,
+						Name:   "authors",
+						Columns: ordered.NewMap[string, sqlschema.Column](
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "author_id",
+								Value: &sqlschema.BaseColumn{
+									SQLType:    "bigint",
+									IsIdentity: true,
+								},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "first_name",
+								Value: &sqlschema.BaseColumn{
+									SQLType: sqltype.VarChar,
+								},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "last_name",
+								Value: &sqlschema.BaseColumn{
+									SQLType: sqltype.VarChar,
+								},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "email",
+								Value: &sqlschema.BaseColumn{
+									SQLType: sqltype.VarChar,
+								},
+							},
+						),
+						PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("author_id")},
+						UniqueConstraints: []sqlschema.Unique{
+							{Columns: sqlschema.NewColumns("first_name", "last_name")},
+							{Columns: sqlschema.NewColumns("email")},
+						},
+					},
+					&sqlschema.BaseTable{
+						Schema: defaultSchema,
+						Name:   "publisher_to_journalists",
+						Columns: ordered.NewMap[string, sqlschema.Column](
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "publisher_id",
+								Value: &sqlschema.BaseColumn{
+									SQLType: sqltype.VarChar,
+								},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "author_id",
+								Value: &sqlschema.BaseColumn{
+									SQLType: "bigint",
+								},
+							},
+						),
+						PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("publisher_id", "author_id")},
+					},
+					&sqlschema.BaseTable{
+						Schema: defaultSchema,
+						Name:   "publishers",
+						Columns: ordered.NewMap[string, sqlschema.Column](
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "publisher_id",
+								Value: &sqlschema.BaseColumn{
+									SQLType:      sqltype.VarChar,
+									DefaultValue: "gen_random_uuid()",
+								},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "publisher_name",
+								Value: &sqlschema.BaseColumn{
+									SQLType: sqltype.VarChar,
+								},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "created_at",
+								Value: &sqlschema.BaseColumn{
+									SQLType:      "timestamp",
+									DefaultValue: "current_timestamp",
+									IsNullable:   true,
+								},
+							},
+						),
+						PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("publisher_id")},
+						UniqueConstraints: []sqlschema.Unique{
+							{Columns: sqlschema.NewColumns("publisher_id", "publisher_name")},
+						},
+					},
+				},
 				wantFKs: []sqlschema.ForeignKey{
 					{
 						From: sqlschema.NewColumnReference("articles", "publisher_id"),
@@ -292,38 +280,35 @@ func TestDatabaseInspector_Inspect(t *testing.T) {
 			{
 				name:       "inspect admin schema",
 				schemaName: "admin",
-				wantTables: ordered.NewMap[string, sqlschema.Table](
-					ordered.Pair[string, sqlschema.Table]{
-						Key: "offices",
-						Value: &sqlschema.BaseTable{
-							Schema: "admin",
-							Name:   "offices",
-							Columns: ordered.NewMap[string, sqlschema.Column](
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "office_name",
-									Value: &sqlschema.BaseColumn{
-										SQLType: sqltype.VarChar,
-									},
+				wantTables: []sqlschema.Table{
+					&sqlschema.BaseTable{
+						Schema: "admin",
+						Name:   "offices",
+						Columns: ordered.NewMap[string, sqlschema.Column](
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "office_name",
+								Value: &sqlschema.BaseColumn{
+									SQLType: sqltype.VarChar,
 								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "publisher_id",
-									Value: &sqlschema.BaseColumn{
-										SQLType:    sqltype.VarChar,
-										IsNullable: true,
-									},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "publisher_id",
+								Value: &sqlschema.BaseColumn{
+									SQLType:    sqltype.VarChar,
+									IsNullable: true,
 								},
-								ordered.Pair[string, sqlschema.Column]{
-									Key: "publisher_name",
-									Value: &sqlschema.BaseColumn{
-										SQLType:    sqltype.VarChar,
-										IsNullable: true,
-									},
+							},
+							ordered.Pair[string, sqlschema.Column]{
+								Key: "publisher_name",
+								Value: &sqlschema.BaseColumn{
+									SQLType:    sqltype.VarChar,
+									IsNullable: true,
 								},
-							),
-							PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("office_name")},
-						},
+							},
+						),
+						PrimaryKey: &sqlschema.PrimaryKey{Columns: sqlschema.NewColumns("office_name")},
 					},
-				),
+				},
 				wantFKs: []sqlschema.ForeignKey{
 					{
 						From: sqlschema.NewColumnReference("offices", "publisher_name", "publisher_id"),
@@ -396,17 +381,28 @@ func mustCreateSchema(tb testing.TB, ctx context.Context, db *bun.DB, schema str
 func cmpTables(
 	tb testing.TB,
 	d sqlschema.InspectorDialect,
-	want, got *ordered.Map[string, sqlschema.Table],
+	want, got []sqlschema.Table,
 ) {
 	tb.Helper()
 
 	require.ElementsMatch(tb, tableNames(want), tableNames(got), "different set of tables")
 
 	// Now we are guaranteed to have the same tables.
-	for _, tPair := range want.Pairs() {
-		tableName, wantTable := tPair.Key, tPair.Value
-		gotTable, ok := got.Load(tableName)
-		require.True(tb, ok)
+	// They might still appear in a different order, here's a helper to find matching tables.
+	findGot := func(t testing.TB, name string) sqlschema.Table {
+		t.Helper()
+		for _, t := range got {
+			if t.GetName() == name {
+				return t
+			}
+		}
+		// This should never happen, as we've verified that table names match.
+		require.Fail(t, "cannot find table %q", name)
+		return nil
+	}
+
+	for _, wantTable := range want {
+		gotTable := findGot(tb, wantTable.GetName())
 		cmpColumns(tb, d, wantTable.GetName(), wantTable.GetColumns(), gotTable.GetColumns())
 		cmpConstraints(tb, wantTable.(*sqlschema.BaseTable), gotTable.(*sqlschema.BaseTable))
 	}
@@ -497,8 +493,11 @@ func cmpConstraints(tb testing.TB, want, got *sqlschema.BaseTable) {
 	require.ElementsMatch(tb, stripNames(want.UniqueConstraints), stripNames(got.UniqueConstraints), "table %q does not have expected unique constraints (listA=want, listB=got)", want.Name)
 }
 
-func tableNames(tables *ordered.Map[string, sqlschema.Table]) []string {
-	return tables.Keys()
+func tableNames(tables []sqlschema.Table) (names []string) {
+	for i := range tables {
+		names = append(names, tables[i].GetName())
+	}
+	return
 }
 
 func formatType(c sqlschema.Column) string {
@@ -545,8 +544,8 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 			require.NoError(t, err)
 
 			gotTables := got.GetTables()
-			require.Equal(t, 1, gotTables.Len())
-			for _, table := range gotTables.Values() {
+			require.Len(t, gotTables, 1)
+			for _, table := range gotTables {
 				cmpColumns(t, dialect.(sqlschema.InspectorDialect), "model", want, table.GetColumns())
 				return
 			}
@@ -590,8 +589,8 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 			require.NoError(t, err)
 
 			gotTables := got.GetTables()
-			require.Equal(t, 1, gotTables.Len())
-			for _, table := range gotTables.Values() {
+			require.Len(t, gotTables, 1)
+			for _, table := range gotTables {
 				cmpColumns(t, dialect.(sqlschema.InspectorDialect), "model", want, table.GetColumns())
 			}
 		})
@@ -619,8 +618,8 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 			require.NoError(t, err)
 
 			gotTables := got.GetTables()
-			require.Equal(t, 1, gotTables.Len())
-			for _, table := range gotTables.Values() {
+			require.Len(t, gotTables, 1)
+			for _, table := range gotTables {
 				cmpConstraints(t, want, &table.(*sqlschema.BunTable).BaseTable)
 				return
 			}
@@ -641,8 +640,8 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 			require.NoError(t, err)
 
 			gotTables := got.GetTables()
-			require.Equal(t, 1, gotTables.Len())
-			for _, table := range gotTables.Values() {
+			require.Len(t, gotTables, 1)
+			for _, table := range gotTables {
 				pk := table.GetPrimaryKey()
 				require.NotNilf(t, pk, "did not register primary key, want (%s)", want)
 				require.Equal(t, want, pk.Columns, "wrong primary key columns")
@@ -663,8 +662,8 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 			require.NoError(t, err)
 
 			gotTables := got.GetTables()
-			require.Equal(t, 1, gotTables.Len())
-			for _, table := range gotTables.Values() {
+			require.Len(t, gotTables, 1)
+			for _, table := range gotTables {
 				require.Equal(t, "custom_schema", table.GetSchema(), "wrong schema name")
 				require.Equal(t, "model", table.GetName(), "wrong table name")
 				return
@@ -688,8 +687,8 @@ func TestBunModelInspector_Inspect(t *testing.T) {
 			require.NoError(t, err)
 
 			gotTables := got.GetTables()
-			require.Equal(t, 1, gotTables.Len())
-			for _, table := range gotTables.Values() {
+			require.Len(t, gotTables, 1)
+			for _, table := range gotTables {
 				require.Equal(t, "want", table.GetSchema(), "wrong schema name")
 				require.Equal(t, "keep_me", table.GetName(), "wrong table name")
 				return

--- a/internal/dbtest/inspect_test.go
+++ b/internal/dbtest/inspect_test.go
@@ -73,6 +73,10 @@ type Journalist struct {
 }
 
 func TestDatabaseInspector_Inspect(t *testing.T) {
+	if isRaceTest {
+		t.Skip("TODO: fix race test")
+	}
+
 	testEachDB(t, func(t *testing.T, dbName string, db *bun.DB) {
 		defaultSchema := db.Dialect().DefaultSchema()
 

--- a/internal/dbtest/migrate_test.go
+++ b/internal/dbtest/migrate_test.go
@@ -700,7 +700,7 @@ func testAddDropColumn(t *testing.T, db *bun.DB) {
 	type TableAfter struct {
 		bun.BaseModel `bun:"table:column_madness"`
 		DoNotTouch    string `bun:"do_not_touch"`
-		AddMe         bool   `bun:"addme"`
+		AddMe         int64  `bun:"addme,autoincrement"`
 	}
 
 	wantTables := []sqlschema.Table{
@@ -714,9 +714,10 @@ func testAddDropColumn(t *testing.T, db *bun.DB) {
 					IsNullable: true,
 				},
 				&sqlschema.BaseColumn{
-					Name:       "addme",
-					SQLType:    sqltype.Boolean,
-					IsNullable: true,
+					Name:            "addme",
+					SQLType:         sqltype.BigInt,
+					IsNullable:      false,
+					IsAutoIncrement: true,
 				},
 			},
 		},

--- a/internal/dbtest/migrate_test.go
+++ b/internal/dbtest/migrate_test.go
@@ -1033,7 +1033,7 @@ func testNothingToMigrate(t *testing.T, db *bun.DB) {
 		AlwaysBlue string `bun:"colour,default:'blue'"`
 
 		// Check that no superficial migrations are generated for `autoincrement` columns.
-		BigInt int64 `bun:",autoincrement"`
+		BigInt int64 `bun:",pk,autoincrement"`
 	}
 
 	ctx := context.Background()

--- a/internal/dbtest/migrate_test.go
+++ b/internal/dbtest/migrate_test.go
@@ -569,6 +569,7 @@ func testChangeColumnType_AutoCast(t *testing.T, db *bun.DB) {
 		EmptyDefault string    `bun:"empty_default"`
 		Nullable     string    `bun:"not_null"`
 		TypeOverride string    `bun:"type:varchar(100)"`
+		Incremented  int       `bun:"incremented"`
 		// ManyValues    []string  `bun:",array"`
 	}
 
@@ -581,6 +582,7 @@ func testChangeColumnType_AutoCast(t *testing.T, db *bun.DB) {
 		EmptyDefault string    `bun:"empty_default,default:''"`      // '' empty string default
 		NotNullable  string    `bun:"not_null,notnull"`              // added NOT NULL
 		TypeOverride string    `bun:"type:varchar(200)"`             // new length
+		Incremented  int       `bun:"incremented,autoincrement"`     // make autoincremented
 		// ManyValues    []string  `bun:",array"`                    // did not change
 	}
 
@@ -622,6 +624,12 @@ func testChangeColumnType_AutoCast(t *testing.T, db *bun.DB) {
 					SQLType:    "varchar",
 					IsNullable: true,
 					VarcharLen: 200,
+				},
+				&sqlschema.BaseColumn{
+					Name:            "incremented",
+					SQLType:         "bigint",
+					IsNullable:      false,
+					IsAutoIncrement: true,
 				},
 				// &sqlschema.BaseColumn{
 				// 	Name:    "many_values",

--- a/internal/dbtest/migrate_test.go
+++ b/internal/dbtest/migrate_test.go
@@ -1033,9 +1033,7 @@ func testNothingToMigrate(t *testing.T, db *bun.DB) {
 		AlwaysBlue string `bun:"colour,default:'blue'"`
 
 		// Check that no superficial migrations are generated for `autoincrement` columns.
-		BigInt   int64 `bun:",autoincrement"`
-		Int      int32 `bun:",autoincrement"`
-		SmallInt int16 `bun:",autoincrement"`
+		BigInt int64 `bun:",autoincrement"`
 	}
 
 	ctx := context.Background()

--- a/internal/dbtest/migrate_test.go
+++ b/internal/dbtest/migrate_test.go
@@ -1045,10 +1045,10 @@ func testNothingToMigrate(t *testing.T, db *bun.DB) {
 	}
 
 	ctx := context.Background()
-	mustResetModel(t, ctx, db, (*BoringThing)(nil))
 	m := newAutoMigratorOrSkip(t, db,
 		migrate.WithModel((*BoringThing)(nil)),
 	)
+	mustResetModel(t, ctx, db, (*BoringThing)(nil))
 
 	// Act
 	_, err := m.Migrate(ctx) // do not use runMigrations because we do not expect any files to be created

--- a/internal/dbtest/migrate_test.go
+++ b/internal/dbtest/migrate_test.go
@@ -1030,6 +1030,11 @@ func testUpdatePrimaryKeys(t *testing.T, db *bun.DB) {
 func testNothingToMigrate(t *testing.T, db *bun.DB) {
 	type BoringThing struct {
 		AlwaysBlue string `bun:"colour,default:'blue'"`
+
+		// Check that no superficial migrations are generated for `autoincrement` columns.
+		BigInt   int64 `bun:",autoincrement"`
+		Int      int32 `bun:",autoincrement"`
+		SmallInt int16 `bun:",autoincrement"`
 	}
 
 	ctx := context.Background()
@@ -1090,7 +1095,6 @@ func testExcludeForeignKeys(t *testing.T, db *bun.DB) {
 
 	// Assert
 	state := inspect(ctx)
-
 	require.Contains(t, state.ForeignKeys, excluded,
 		"expected FK constraint things.owner_name -> owners.name")
 }

--- a/migrate/auto.go
+++ b/migrate/auto.go
@@ -352,7 +352,7 @@ func (c *changeset) apply(ctx context.Context, db *bun.DB, m sqlschema.Migrator)
 	}
 
 	for _, op := range c.operations {
-		if _, isComment := op.(*comment); isComment {
+		if _, skip := op.(*Unimplemented); skip {
 			continue
 		}
 
@@ -375,9 +375,9 @@ func (c *changeset) WriteTo(w io.Writer, m sqlschema.Migrator) error {
 
 	b := internal.MakeQueryBytes()
 	for _, op := range c.operations {
-		if c, isComment := op.(*comment); isComment {
+		if comment, isComment := op.(*Unimplemented); isComment {
 			b = append(b, "/*\n"...)
-			b = append(b, *c...)
+			b = append(b, *comment...)
 			b = append(b, "\n*/"...)
 			continue
 		}

--- a/migrate/diff.go
+++ b/migrate/diff.go
@@ -1,6 +1,7 @@
 package migrate
 
 import (
+	"github.com/uptrace/bun/internal/ordered"
 	"github.com/uptrace/bun/migrate/sqlschema"
 )
 
@@ -22,8 +23,8 @@ func diff(got, want sqlschema.Database, opts ...diffOption) *changeset {
 }
 
 func (d *detector) detectChanges() *changeset {
-	currentTables := d.current.GetTables()
-	targetTables := d.target.GetTables()
+	currentTables := toOrderedMap(d.current.GetTables())
+	targetTables := toOrderedMap(d.target.GetTables())
 
 RenameCreate:
 	for _, wantPair := range targetTables.Pairs() {
@@ -97,6 +98,15 @@ RenameCreate:
 	}
 
 	return &d.changes
+}
+
+// toOrderedMap transforms a slice of objects to an ordered map, using return of GetName() as key.
+func toOrderedMap[V interface{ GetName() string }](named []V) *ordered.Map[string, V] {
+	m := ordered.NewMap[string, V]()
+	for _, v := range named {
+		m.Store(v.GetName(), v)
+	}
+	return m
 }
 
 // detechColumnChanges finds renamed columns and, if checkType == true, columns with changed type.
@@ -311,7 +321,6 @@ func equalSignatures(t1, t2 sqlschema.Table, eq CompareTypeFunc) bool {
 // signature is a set of column definitions, which allows "relation/name-agnostic" comparison between them;
 // meaning that two columns are considered equal if their types are the same.
 type signature struct {
-
 	// underlying stores the number of occurences for each unique column type.
 	// It helps to account for the fact that a table might have multiple columns that have the same type.
 	underlying map[sqlschema.BaseColumn]int

--- a/migrate/diff.go
+++ b/migrate/diff.go
@@ -111,8 +111,8 @@ func toOrderedMap[V interface{ GetName() string }](named []V) *ordered.Map[strin
 
 // detechColumnChanges finds renamed columns and, if checkType == true, columns with changed type.
 func (d *detector) detectColumnChanges(current, target sqlschema.Table, checkType bool) {
-	currentColumns := current.GetColumns()
-	targetColumns := target.GetColumns()
+	currentColumns := toOrderedMap(current.GetColumns())
+	targetColumns := toOrderedMap(target.GetColumns())
 
 ChangeRename:
 	for _, tPair := range targetColumns.Pairs() {
@@ -339,7 +339,7 @@ func newSignature(t sqlschema.Table, eq CompareTypeFunc) signature {
 
 // scan iterates over table's field and counts occurrences of each unique column definition.
 func (s *signature) scan(t sqlschema.Table) {
-	for _, icol := range t.GetColumns().Values() {
+	for _, icol := range t.GetColumns() {
 		scanCol := icol.(*sqlschema.BaseColumn)
 		// This is slightly more expensive than if the columns could be compared directly
 		// and we always did s.underlying[col]++, but we get type-equivalence in return.

--- a/migrate/operations.go
+++ b/migrate/operations.go
@@ -56,7 +56,7 @@ func (op *DropTableOp) DependsOn(another Operation) bool {
 // GetReverse for a DropTable returns a no-op migration. Logically, CreateTable is the reverse,
 // but DropTable does not have the table's definition to create one.
 func (op *DropTableOp) GetReverse() Operation {
-	c := comment(fmt.Sprintf("WARNING: \"DROP TABLE %s\" cannot be reversed automatically because table definition is not available", op.TableName))
+	c := Unimplemented(fmt.Sprintf("WARNING: \"DROP TABLE %s\" cannot be reversed automatically because table definition is not available", op.TableName))
 	return &c
 }
 
@@ -224,7 +224,6 @@ func (op *AddUniqueConstraintOp) DependsOn(another Operation) bool {
 	default:
 		return false
 	}
-
 }
 
 // DropUniqueConstraintOp drops a UNIQUE constraint.
@@ -326,15 +325,15 @@ func (op *ChangePrimaryKeyOp) GetReverse() Operation {
 	}
 }
 
-// comment denotes an Operation that cannot be executed.
+// Unimplemented denotes an Operation that cannot be executed.
 //
 // Operations, which cannot be reversed due to current technical limitations,
-// may return &comment with a helpful message from their GetReverse() method.
+// may have their GetReverse() return &Unimplemented with a helpful message.
 //
-// Chnagelog should skip it when applying operations or output as log message,
-// and write it as an SQL comment when creating migration files.
-type comment string
+// When applying operations, changelog should skip it or output as a log message,
+// and write it as an SQL Unimplemented when creating migration files.
+type Unimplemented string
 
-var _ Operation = (*comment)(nil)
+var _ Operation = (*Unimplemented)(nil)
 
-func (c *comment) GetReverse() Operation { return c }
+func (reason *Unimplemented) GetReverse() Operation { return reason }

--- a/migrate/sqlschema/database.go
+++ b/migrate/sqlschema/database.go
@@ -4,12 +4,11 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/uptrace/bun/internal/ordered"
 	"github.com/uptrace/bun/schema"
 )
 
 type Database interface {
-	GetTables() *ordered.Map[string, Table]
+	GetTables() []Table
 	GetForeignKeys() map[ForeignKey]string
 }
 
@@ -20,11 +19,11 @@ var _ Database = (*BaseDatabase)(nil)
 // Dialects and only dialects can use it to implement the Database interface.
 // Other packages must use the Database interface.
 type BaseDatabase struct {
-	Tables      *ordered.Map[string, Table]
+	Tables      []Table
 	ForeignKeys map[ForeignKey]string
 }
 
-func (ds BaseDatabase) GetTables() *ordered.Map[string, Table] {
+func (ds BaseDatabase) GetTables() []Table {
 	return ds.Tables
 }
 

--- a/migrate/sqlschema/inspector.go
+++ b/migrate/sqlschema/inspector.go
@@ -113,6 +113,10 @@ type inspector struct {
 
 // BunModelInspector creates the current project state from the passed bun.Models.
 // Do not recycle BunModelInspector for different sets of models, as older models will not be de-registerred before the next run.
+//
+// BunModelInspector does not know which the database's dialect, so it does not
+// assume any default schema name. Always specify the target schema name via
+// WithSchemaName option to receive meaningful results.
 type BunModelInspector struct {
 	InspectorConfig
 	tables *schema.Tables
@@ -138,6 +142,7 @@ func (bmi *BunModelInspector) Inspect(ctx context.Context) (Database, error) {
 			if err != nil {
 				return nil, fmt.Errorf("parse length in %q: %w", f.CreateTableSQLType, err)
 			}
+
 			columns = append(columns, &BaseColumn{
 				Name:            f.Name,
 				SQLType:         strings.ToLower(sqlType), // TODO(dyma): maybe this is not necessary after Column.Eq()

--- a/migrate/sqlschema/inspector.go
+++ b/migrate/sqlschema/inspector.go
@@ -126,7 +126,6 @@ func (bmi *BunModelInspector) Inspect(ctx context.Context) (Database, error) {
 		BaseDatabase: BaseDatabase{
 			ForeignKeys: make(map[ForeignKey]string),
 		},
-		Tables: ordered.NewMap[string, Table](),
 	}
 	for _, t := range bmi.tables.All() {
 		if t.Schema != bmi.SchemaName {
@@ -186,7 +185,7 @@ func (bmi *BunModelInspector) Inspect(ctx context.Context) (Database, error) {
 		// produces
 		// 	schema.Table{ Schema: "favourite", Name: "favourite.books" }
 		tableName := strings.TrimPrefix(t.Name, t.Schema+".")
-		state.Tables.Store(tableName, &BunTable{
+		state.Tables = append(state.Tables, &BunTable{
 			BaseTable: BaseTable{
 				Schema:            t.Schema,
 				Name:              tableName,
@@ -236,7 +235,7 @@ func parseLen(typ string) (string, int, error) {
 }
 
 // exprOrLiteral converts string to lowercase, if it does not contain a string literal 'lit'
-// and trims the surrounding '' otherwise.
+// and trims the surrounding ” otherwise.
 // Use it to ensure that user-defined default values in the models are always comparable
 // to those returned by the database inspector, regardless of the case convention in individual drivers.
 func exprOrLiteral(s string) string {
@@ -250,10 +249,10 @@ func exprOrLiteral(s string) string {
 type BunModelSchema struct {
 	BaseDatabase
 
-	Tables *ordered.Map[string, Table]
+	Tables []Table
 }
 
-func (ms BunModelSchema) GetTables() *ordered.Map[string, Table] {
+func (ms BunModelSchema) GetTables() []Table {
 	return ms.Tables
 }
 

--- a/migrate/sqlschema/inspector.go
+++ b/migrate/sqlschema/inspector.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/uptrace/bun"
-	"github.com/uptrace/bun/internal/ordered"
 	"github.com/uptrace/bun/schema"
 )
 
@@ -132,14 +131,14 @@ func (bmi *BunModelInspector) Inspect(ctx context.Context) (Database, error) {
 			continue
 		}
 
-		columns := ordered.NewMap[string, Column]()
+		var columns []Column
 		for _, f := range t.Fields {
 
 			sqlType, length, err := parseLen(f.CreateTableSQLType)
 			if err != nil {
 				return nil, fmt.Errorf("parse length in %q: %w", f.CreateTableSQLType, err)
 			}
-			columns.Store(f.Name, &BaseColumn{
+			columns = append(columns, &BaseColumn{
 				Name:            f.Name,
 				SQLType:         strings.ToLower(sqlType), // TODO(dyma): maybe this is not necessary after Column.Eq()
 				VarcharLen:      length,

--- a/migrate/sqlschema/table.go
+++ b/migrate/sqlschema/table.go
@@ -1,13 +1,9 @@
 package sqlschema
 
-import (
-	"github.com/uptrace/bun/internal/ordered"
-)
-
 type Table interface {
 	GetSchema() string
 	GetName() string
-	GetColumns() *ordered.Map[string, Column]
+	GetColumns() []Column
 	GetPrimaryKey() *PrimaryKey
 	GetUniqueConstraints() []Unique
 }
@@ -23,7 +19,7 @@ type BaseTable struct {
 	Name   string
 
 	// ColumnDefinitions map each column name to the column definition.
-	Columns *ordered.Map[string, Column]
+	Columns []Column
 
 	// PrimaryKey holds the primary key definition.
 	// A nil value means that no primary key is defined for the table.
@@ -47,7 +43,7 @@ func (td *BaseTable) GetName() string {
 	return td.Name
 }
 
-func (td *BaseTable) GetColumns() *ordered.Map[string, Column] {
+func (td *BaseTable) GetColumns() []Column {
 	return td.Columns
 }
 

--- a/model.go
+++ b/model.go
@@ -39,6 +39,7 @@ type TableModel interface {
 	getJoin(string) *relationJoin
 	getJoins() []relationJoin
 	addJoin(relationJoin) *relationJoin
+	clone() TableModel
 
 	rootValue() reflect.Value
 	parentIndex() []int

--- a/model_table_has_many.go
+++ b/model_table_has_many.go
@@ -130,6 +130,16 @@ func (m *hasManyModel) parkStruct() error {
 	return nil
 }
 
+func (m *hasManyModel) clone() TableModel {
+	return &hasManyModel{
+		sliceTableModel: m.sliceTableModel.clone().(*sliceTableModel),
+		baseTable:       m.baseTable,
+		rel:             m.rel,
+		baseValues:      m.baseValues,
+		structKey:       m.structKey,
+	}
+}
+
 func baseValues(model TableModel, fields []*schema.Field) map[internal.MapKey][]reflect.Value {
 	fieldIndex := model.Relation().Field.Index
 	m := make(map[internal.MapKey][]reflect.Value)

--- a/model_table_m2m.go
+++ b/model_table_m2m.go
@@ -130,3 +130,13 @@ func (m *m2mModel) parkStruct() error {
 
 	return nil
 }
+
+func (m *m2mModel) clone() TableModel {
+	return &m2mModel{
+		sliceTableModel: m.sliceTableModel.clone().(*sliceTableModel),
+		baseTable:       m.baseTable,
+		rel:             m.rel,
+		baseValues:      m.baseValues,
+		structKey:       m.structKey,
+	}
+}

--- a/model_table_slice.go
+++ b/model_table_slice.go
@@ -124,3 +124,13 @@ func (m *sliceTableModel) updateSoftDeleteField(tm time.Time) error {
 	}
 	return nil
 }
+
+func (m *sliceTableModel) clone() TableModel {
+	return &sliceTableModel{
+		structTableModel: *m.structTableModel.clone().(*structTableModel),
+		slice:            m.slice,
+		sliceLen:         m.sliceLen,
+		sliceOfPtr:       m.sliceOfPtr,
+		nextElem:         m.nextElem,
+	}
+}

--- a/model_table_struct.go
+++ b/model_table_struct.go
@@ -337,6 +337,23 @@ func (m *structTableModel) AppendNamedArg(
 	return m.table.AppendNamedArg(fmter, b, name, m.strct)
 }
 
+func (m *structTableModel) clone() TableModel {
+	return &structTableModel{
+		db:            m.db,
+		table:         m.table,
+		rel:           m.rel,
+		joins:         append([]relationJoin{}, m.joins...),
+		dest:          m.dest,
+		root:          m.root,
+		index:         append([]int{}, m.index...),
+		strct:         m.strct,
+		structInited:  m.structInited,
+		structInitErr: m.structInitErr,
+		columns:       append([]string{}, m.columns...),
+		scanIndex:     m.scanIndex,
+	}
+}
+
 // sqlite3 sometimes does not unquote columns.
 func unquote(s string) string {
 	if s == "" {

--- a/query_select.go
+++ b/query_select.go
@@ -1126,7 +1126,7 @@ func (q *SelectQuery) Clone() *SelectQuery {
 				db:             q.db,
 				table:          q.table,
 				model:          q.model,
-				tableModel:     q.tableModel,
+				tableModel:     q.tableModel.clone(),
 				with:           make([]withQuery, len(q.with)),
 				tables:         cloneArgs(q.tables),
 				columns:        cloneArgs(q.columns),

--- a/schema/table.go
+++ b/schema/table.go
@@ -538,6 +538,7 @@ func (t *Table) newField(sf reflect.StructField, tag tagparser.Tag) *Field {
 	}
 	if tag.HasOption("autoincrement") {
 		field.AutoIncrement = true
+		field.NotNull = true
 		field.NullZero = true
 	}
 	if tag.HasOption("identity") {

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -322,4 +322,17 @@ func TestTable(t *testing.T) {
 
 		require.Equal(t, table.FieldMap["foo"].SQLName, table.FieldMap["alt_name"].SQLName)
 	})
+
+	t.Run("autoincrement is not nullable", func(t *testing.T) {
+		type Thing struct {
+			Counter int `bun:",autoincrement"`
+		}
+
+		table := tables.Get(reflect.TypeFor[*Thing]())
+
+		require.Contains(t, table.FieldMap, "counter")
+		counter := table.FieldMap["counter"]
+		require.True(t, counter.AutoIncrement, "autoincrement")
+		require.True(t, counter.NotNull, "not null")
+	})
 }


### PR DESCRIPTION
This PR contains changes from a range of commits from the original repository.

**Commit Range:** `4055827..fe5bcc1`
**Files Changed:** 25 (24 programming files)
**Programming Ratio:** 96.0%

**Commits included:**
- Merge pull request #1192 from uptrace/fix/automigrate-autoincrement
- fix: start sequence with last+1
- chore: skip test before creating tables
- feat: support changing column type to SERIAL
- test: make serial column a PK
- test: create 1 autoincrement column
- Merge pull request #1187 from emilioforrer/feature/add-custom-channel-overflow-handler
- test: add 'serial' column
- feat: set notnull=true for autoincrement columns
- fix: report BIGSERIAL ~ BIGINT in pgdialect
... and 13 more commits